### PR TITLE
Chord to pitches with inversions

### DIFF
--- a/src/MusicTheory/Chord.elm
+++ b/src/MusicTheory/Chord.elm
@@ -1,38 +1,115 @@
 module MusicTheory.Chord exposing
     ( Chord
+    , ChordError(..)
+    , allChords
     , chord
     , chordClass
+    , inversion
+    , possibleInversions
     , root
     , toPitchClasses
+    , toPitchesFromOctave
+    , withInversion
     )
 
 import MusicTheory.ChordClass as ChordClass
+import MusicTheory.Inversion as Inversion
+import MusicTheory.Octave as Octave
+import MusicTheory.Pitch as Pitch
 import MusicTheory.PitchClass as PitchClass
+import Result.Extra
+import Util.List
 
 
 type Chord
-    = Chord PitchClass.PitchClass ChordClass.ChordClass
+    = Chord PitchClass.PitchClass ChordClass.ChordClass Inversion.Inversion
+
+
+type ChordError
+    = InvalidInversion
+    | PitchConversionError
 
 
 chord : PitchClass.PitchClass -> ChordClass.ChordClass -> Chord
 chord rootPitchClass theChordClass =
-    Chord rootPitchClass theChordClass
+    Chord rootPitchClass theChordClass Inversion.none
 
 
 root : Chord -> PitchClass.PitchClass
-root (Chord rootPitchClass _) =
+root (Chord rootPitchClass _ _) =
     rootPitchClass
 
 
 chordClass : Chord -> ChordClass.ChordClass
-chordClass (Chord _ theChordClass) =
+chordClass (Chord _ theChordClass _) =
     theChordClass
 
 
+inversion : Chord -> Inversion.Inversion
+inversion (Chord _ _ theInversion) =
+    theInversion
+
+
 toPitchClasses : Chord -> List PitchClass.PitchClass
-toPitchClasses (Chord rootPitchClass theChordClass) =
-    List.map
-        (\interval ->
-            PitchClass.transpose interval rootPitchClass
-        )
-        (ChordClass.toIntervals theChordClass)
+toPitchClasses (Chord rootPitchClass theChordClass theInversion) =
+    ChordClass.toIntervals theChordClass
+        |> List.map
+            (\interval -> PitchClass.transpose interval rootPitchClass)
+        |> Util.List.rotateLeft (Inversion.toInt theInversion)
+
+
+toPitchesFromOctave : Octave.Octave -> Chord -> Result ChordError (List Pitch.Pitch)
+toPitchesFromOctave octave theChord =
+    case toPitchClasses theChord of
+        [] ->
+            Ok []
+
+        rootPitchClass :: remainingPitchClasses ->
+            let
+                theRoot =
+                    Ok <| Pitch.fromPitchClass octave rootPitchClass
+            in
+            remainingPitchClasses
+                |> List.foldl
+                    (\pc ( pitchResult, acc ) ->
+                        let
+                            next =
+                                Result.andThen
+                                    (\pitch -> Pitch.firstAbove pc pitch)
+                                    pitchResult
+                        in
+                        ( next, List.append acc [ next ] )
+                    )
+                    ( theRoot, [ theRoot ] )
+                |> Tuple.second
+                |> Result.Extra.combine
+                |> Result.mapError (\_ -> PitchConversionError)
+
+
+allChords : Chord -> List (List Pitch.Pitch)
+allChords thisChord =
+    Octave.allValid
+        |> List.map (\octave -> toPitchesFromOctave octave thisChord)
+        |> Result.Extra.partition
+        |> Tuple.first
+
+
+withInversion : Inversion.Inversion -> Chord -> Result ChordError Chord
+withInversion theInversion theChord =
+    case List.member theInversion (possibleInversions theChord) of
+        True ->
+            case theChord of
+                Chord theRoot theChordClass _ ->
+                    Ok (Chord theRoot theChordClass theInversion)
+
+        False ->
+            Err InvalidInversion
+
+
+possibleInversions : Chord -> List Inversion.Inversion
+possibleInversions theChord =
+    toPitchClasses theChord
+        |> List.length
+        |> (+) -1
+        |> List.range 0
+        |> List.map Inversion.fromInt

--- a/src/MusicTheory/ChordClass.elm
+++ b/src/MusicTheory/ChordClass.elm
@@ -49,7 +49,7 @@ toIntervals : ChordClass -> List Interval
 toIntervals theChordClass =
     case theChordClass of
         ChordClass chordFactors ->
-            chordFactors
+            List.sortBy Interval.semitones chordFactors
 
 
 all : List ChordClass

--- a/src/MusicTheory/Inversion.elm
+++ b/src/MusicTheory/Inversion.elm
@@ -1,0 +1,67 @@
+module MusicTheory.Inversion exposing
+    ( Inversion
+    , fifth
+    , first
+    , fourth
+    , fromInt
+    , none
+    , second
+    , seventh
+    , sixth
+    , third
+    , toInt
+    )
+
+
+type Inversion
+    = Inversion Int
+
+
+fromInt : Int -> Inversion
+fromInt inv =
+    Inversion inv
+
+
+toInt : Inversion -> Int
+toInt (Inversion inv) =
+    inv
+
+
+none : Inversion
+none =
+    fromInt 0
+
+
+first : Inversion
+first =
+    fromInt 1
+
+
+second : Inversion
+second =
+    fromInt 2
+
+
+third : Inversion
+third =
+    fromInt 3
+
+
+fourth : Inversion
+fourth =
+    fromInt 4
+
+
+fifth : Inversion
+fifth =
+    fromInt 5
+
+
+sixth : Inversion
+sixth =
+    fromInt 6
+
+
+seventh : Inversion
+seventh =
+    fromInt 7

--- a/src/Util/List.elm
+++ b/src/Util/List.elm
@@ -1,0 +1,15 @@
+module Util.List exposing (rotateLeft)
+
+
+rotateLeft : Int -> List a -> List a
+rotateLeft amount list =
+    if amount <= 0 then
+        list
+
+    else
+        case list of
+            [] ->
+                []
+
+            x :: xs ->
+                rotateLeft (amount - 1) (xs ++ [ x ])

--- a/tests/Test/Chord.elm
+++ b/tests/Test/Chord.elm
@@ -1,0 +1,132 @@
+module Test.Chord exposing (all)
+
+import Expect
+import MusicTheory.Chord as Chord
+import MusicTheory.ChordClass as ChordClass
+import MusicTheory.Inversion as Inversion
+import MusicTheory.Octave as Octave
+import MusicTheory.Pitch as Pitch
+import MusicTheory.PitchClass as PitchClass
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "all"
+        [ describe "toPitchClasses"
+            [ test "Should return C E G from C major triad" <|
+                \_ ->
+                    Chord.chord PitchClass.c ChordClass.major
+                        |> Chord.toPitchClasses
+                        |> Expect.equal [ PitchClass.c, PitchClass.e, PitchClass.g ]
+            ]
+        , describe "allChords"
+            [ test "Should return C4 E4 G4 from C major triad in 4th octave" <|
+                \_ ->
+                    let
+                        expected =
+                            [ [ Pitch.c0, Pitch.e0, Pitch.g0 ]
+                            , [ Pitch.c1, Pitch.e1, Pitch.g1 ]
+                            , [ Pitch.c2, Pitch.e2, Pitch.g2 ]
+                            , [ Pitch.c3, Pitch.e3, Pitch.g3 ]
+                            , [ Pitch.c4, Pitch.e4, Pitch.g4 ]
+                            , [ Pitch.c5, Pitch.e5, Pitch.g5 ]
+                            , [ Pitch.c6, Pitch.e6, Pitch.g6 ]
+                            , [ Pitch.c7, Pitch.e7, Pitch.g7 ]
+                            , [ Pitch.c8, Pitch.e8, Pitch.g8 ]
+                            ]
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.allChords
+                    in
+                    Expect.equal expected result
+            ]
+        , describe "possibleInversions"
+            [ test "Should return three inversions from C major triad" <|
+                \_ ->
+                    let
+                        expected =
+                            [ Inversion.none
+                            , Inversion.first
+                            , Inversion.second
+                            ]
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.possibleInversions
+                    in
+                    Expect.equal expected result
+            ]
+        , describe "withInversion"
+            [ test "Should return the first inversion from C major triad first inversion" <|
+                \_ ->
+                    let
+                        expected =
+                            Ok [ PitchClass.e, PitchClass.g, PitchClass.c ]
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.withInversion Inversion.first
+                                |> Result.map Chord.toPitchClasses
+                    in
+                    Expect.equal expected result
+            , test "Should return E G C for the first inversion of C major triad first inversion" <|
+                \_ ->
+                    let
+                        expected =
+                            Ok Inversion.first
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.withInversion Inversion.first
+                                |> Result.map Chord.inversion
+                    in
+                    Expect.equal expected result
+            , test "Should return error for third inversion of C major triad" <|
+                \_ ->
+                    let
+                        expected =
+                            Err Chord.InvalidInversion
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.withInversion Inversion.third
+                    in
+                    Expect.equal expected result
+            , test "Should return E4 G4 C5 for the first inversion of C major triad first inversion" <|
+                \_ ->
+                    let
+                        expected =
+                            Ok [ Pitch.e4, Pitch.g4, Pitch.c5 ]
+
+                        result =
+                            Chord.chord PitchClass.c ChordClass.major
+                                |> Chord.withInversion Inversion.first
+                                |> Result.andThen (Chord.toPitchesFromOctave Octave.four)
+                    in
+                    Expect.equal expected result
+            ]
+        , describe "inOctave"
+            [ test "Should return C4 E4 G4 from C major triad in 4th octave" <|
+                \_ ->
+                    Chord.chord PitchClass.c ChordClass.major
+                        |> Chord.toPitchesFromOctave Octave.four
+                        |> Expect.equal (Ok [ Pitch.c4, Pitch.e4, Pitch.g4 ])
+            , test "Should return C4 E4 G4 from C dominant thirteenth in 4th octave" <|
+                \_ ->
+                    Chord.chord PitchClass.c ChordClass.dominantThirteenth
+                        |> Chord.toPitchesFromOctave Octave.four
+                        |> Expect.equal
+                            (Ok
+                                [ Pitch.c4
+                                , Pitch.e4
+                                , Pitch.g4
+                                , Pitch.bFlat4
+                                , Pitch.d5
+                                , Pitch.f5
+                                , Pitch.a5
+                                ]
+                            )
+            ]
+        ]

--- a/tests/Test/Util/List.elm
+++ b/tests/Test/Util/List.elm
@@ -1,0 +1,22 @@
+module Test.Util.List exposing (all)
+
+import Expect
+import Test exposing (Test, describe, test)
+import Util.List
+
+
+all : Test
+all =
+    describe "all"
+        [ test "rotateLeft" <|
+            \_ ->
+                let
+                    expected =
+                        [ 2, 3, 1 ]
+
+                    result =
+                        [ 1, 2, 3 ]
+                            |> Util.List.rotateLeft 1
+                in
+                Expect.equal expected result
+        ]


### PR DESCRIPTION
I'm looking to convert chord objects into pitches. I also added the ability to use chord inversions when converting the chords to pitch lists. The biggest problems I had were thinking of reasonable api names and trying to keep the function `toPitchesFromOctave` small and readable.